### PR TITLE
fix: dialog cannot be closed

### DIFF
--- a/src/views/manage-notes/components/topic-detail.tsx
+++ b/src/views/manage-notes/components/topic-detail.tsx
@@ -107,6 +107,9 @@ export const TopicDetail = defineComponent({
               role="dialog"
               class={'modal-card md'}
               title={`专栏 - ${topic.value.name}`}
+              onClose={() => {
+                show.value = false
+              }}
             >
               <NThing>
                 {{


### PR DESCRIPTION
### Description

修复`点滴 - 专栏 - 详情`对话框点击右上角`X`无法关闭

### Linked Issues


### Additional context
