### PR TITLE
fix: graph number overflow

### DIFF
--- a/src/views/analyze/index.tsx
+++ b/src/views/analyze/index.tsx
@@ -167,9 +167,9 @@ export default defineComponent({
     const todayIp = ref<string[]>()
     const graphData = ref(
       {} as {
-        day: any[]
-        week: any[]
-        month: any[]
+        day: Today[]
+        week: Week[]
+        month: Month[]
       },
     )
     const topPaths = ref([] as Path[])
@@ -209,7 +209,7 @@ export default defineComponent({
           container: element,
           autoFit: true,
           height: 250,
-          padding: [30, 20, 70, 30],
+          padding: [30, 20, 70, 40],
         })
         charts[field] = chart
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
当图表纵坐标的数字 `>= 1000` 时，数字无法正确显示

### Additional context

#### 修改前
![one](https://user-images.githubusercontent.com/89030875/211302735-0af5f4cd-5dff-41f9-9d93-8a8e437a264d.jpg)

#### 修改后
![two](https://user-images.githubusercontent.com/89030875/211302799-9a61ba2f-2385-4f43-8f4b-bdc33d043979.jpg)
