### PR TITLE
fix: add yaml parse err message

### DIFF
--- a/src/utils/markdown-parser.ts
+++ b/src/utils/markdown-parser.ts
@@ -2,7 +2,9 @@ import { load } from 'js-yaml'
 
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 export class ParseMarkdownYAML {
-  constructor(private strList: string[]) {}
+  constructor(private strList: string[]) {
+    this.strList = strList
+  }
 
   parse(str: string) {
     const raw = str
@@ -36,8 +38,15 @@ export class ParseMarkdownYAML {
   start() {
     const files = this.strList
     const contents = [] as ParsedModel[]
-    for (const file of files) {
-      contents.push(this.parse(file))
+    for (const [idx, file] of files.entries()) {
+      try {
+        contents.push(this.parse(file))
+      } catch (err) {
+        throw {
+          idx,
+          err,
+        }
+      }
     }
     return contents
   }

--- a/src/views/extra-features/markdown-helper.tsx
+++ b/src/views/extra-features/markdown-helper.tsx
@@ -103,13 +103,21 @@ export default defineComponent(() => {
 
       strList.push(res as string)
     }
-    const parsedList_ = parseMarkdown(strList)
-    message.success('解析完成，结果查看 console 哦')
-    parsedList.value = parsedList_.map((v, index) => ({
-      ...v,
-      filename: fileList.value[index].file?.name ?? '',
-    }))
-    console.log(toRaw(parsedList))
+    try {
+      const parsedList_ = parseMarkdown(strList)
+      message.success('解析完成，结果查看 console 哦')
+      parsedList.value = parsedList_.map((v, index) => ({
+        ...v,
+        filename: fileList.value[index].file?.name ?? '',
+      }))
+      //
+      console.log(toRaw(parsedList))
+    } catch (e: any) {
+      console.error(e.err)
+      message.error(
+        `文件${fileList.value[e.idx].name ?? ''}解析失败，具体信息查看 console`,
+      )
+    }
   }
 
   async function handleUpload(e: MouseEvent) {
@@ -178,7 +186,7 @@ export default defineComponent(() => {
             options={types}
             value={importType.value}
             onUpdateValue={(e) => void (importType.value = e)}
-          ></NSelect>
+          />
         </NFormItem>
         <NFormItem label="准备好了吗.">
           <NSpace vertical>
@@ -234,26 +242,26 @@ export default defineComponent(() => {
           <NSwitch
             value={exportConfig.includeYAMLHeader}
             onUpdateValue={(e) => void (exportConfig.includeYAMLHeader = e)}
-          ></NSwitch>
+          />
         </NFormItem>
         <NFormItem label="是否在第一行显示文章标题">
           <NSwitch
             value={exportConfig.titleBigTitle}
             onUpdateValue={(e) => void (exportConfig.titleBigTitle = e)}
-          ></NSwitch>
+          />
         </NFormItem>
         <NFormItem label="根据 slug 生成文件名">
           <NSwitch
             value={exportConfig.filenameSlug}
             onUpdateValue={(e) => void (exportConfig.filenameSlug = e)}
-          ></NSwitch>
+          />
         </NFormItem>
 
         <NFormItem label="导出元数据 JSON">
           <NSwitch
             value={exportConfig.withMetaJson}
             onUpdateValue={(e) => void (exportConfig.withMetaJson = e)}
-          ></NSwitch>
+          />
         </NFormItem>
 
         <div class="w-full text-right">


### PR DESCRIPTION
### Description

通过message.error，给md解析出现yamlException的时候加上错误提示

### Linked Issues

[issue](https://github.com/mx-space/mx-admin/issues/910)

### Additional context

catch的类型不大好搞，最后直接any了，可以康康
以及lint的原因把组件写成了自闭合元素