### PR TITLE
Add WebGL-based image processing for better performance

### DIFF
--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -58,3 +58,65 @@ export const encodeImageToBlurhash = (image: HTMLImageElement) => {
   const imageData = getImageData(image)
   return encode(imageData.data, imageData.width, imageData.height, 4, 4)
 }
+
+export const encodeImageToBlurhashWebgl = (image: HTMLImageElement) => {
+  const canvas = document.createElement('canvas')
+  const gl = (canvas.getContext('webgl') ||
+    canvas.getContext('experimental-webgl')) as WebGLRenderingContext
+
+  if (!gl) {
+    throw new Error('WebGL not supported')
+  }
+
+  canvas.width = image.naturalWidth
+  canvas.height = image.naturalHeight
+
+  // Create a texture and bind image
+  const texture = gl.createTexture()
+  gl.bindTexture(gl.TEXTURE_2D, texture)
+  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+
+  // Create a framebuffer and attach the texture
+  const framebuffer = gl.createFramebuffer()
+  gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer)
+  gl.framebufferTexture2D(
+    gl.FRAMEBUFFER,
+    gl.COLOR_ATTACHMENT0,
+    gl.TEXTURE_2D,
+    texture,
+    0,
+  )
+
+  // Read the pixels
+  const pixels = new Uint8Array(image.naturalWidth * image.naturalHeight * 4)
+  gl.readPixels(
+    0,
+    0,
+    image.naturalWidth,
+    image.naturalHeight,
+    gl.RGBA,
+    gl.UNSIGNED_BYTE,
+    pixels,
+  )
+
+  // Resize the image to 32x32
+  const resizedCanvas = document.createElement('canvas')
+  resizedCanvas.width = 32
+  resizedCanvas.height = 32
+  const resizedCtx = resizedCanvas.getContext('2d')!
+  const imageData = new ImageData(
+    new Uint8ClampedArray(pixels),
+    image.naturalWidth,
+    image.naturalHeight,
+  )
+  resizedCtx.putImageData(imageData, 0, 0)
+  resizedCtx.drawImage(resizedCanvas, 0, 0, 32, 32)
+  const resizedImageData = resizedCtx.getImageData(0, 0, 32, 32)
+
+  // Encode the resized image to BlurHash
+  return encode(resizedImageData.data, 32, 32, 4, 4)
+}


### PR DESCRIPTION
### Description

This commit includes a new method `encodeImageToBlurhashWebgl` for generating Blurhash using WebGL. This method leverages WebGL for image data processing, which is more efficient compared to using 2D canvas operations, especially when working with larger images.

### Additional context

Tested on Archlinux 6.12.7-arch1-1, Chrome 131.0.6778.108, NVIDIA GeForce RTX 4060, 
it reduced processing time and mitigated the UI stutter during image encoding, particularly with larger images.