### PR TITLE
fix(sidebar): prevent unintended collapse behavior

### DIFF
--- a/src/layouts/sidebar/index.tsx
+++ b/src/layouts/sidebar/index.tsx
@@ -1,16 +1,17 @@
-import { GATEWAY_URL } from '~/constants/env'
-import { KBarWrapper } from '~/components/k-bar'
-import $RouterView from '~/layouts/router-view'
 import { NLayoutContent } from 'naive-ui'
-import { RESTManager } from '~/utils'
 import { computed, defineComponent, watchEffect } from 'vue'
 import { RouterLink } from 'vue-router'
+import type { CSSProperties } from 'vue'
+
+import { KBarWrapper } from '~/components/k-bar'
+import { GATEWAY_URL } from '~/constants/env'
+import $RouterView from '~/layouts/router-view'
+import { RESTManager } from '~/utils'
 
 import { Sidebar } from '../../components/sidebar'
 import { useStoreRef } from '../../hooks/use-store-ref'
 import { UIStore } from '../../stores/ui'
 import styles from './index.module.css'
-import type { CSSProperties } from 'vue'
 
 export const SidebarLayout = defineComponent({
   name: 'SidebarLayout',
@@ -21,7 +22,18 @@ export const SidebarLayout = defineComponent({
     const { meta, b } = useMagicKeys()
     watchEffect(() => {
       if (meta.value && b.value) {
-        collapse.value = !collapse.value
+        // is the focus in the input box?
+        const activeElement = document.activeElement
+        const isInEditor =
+          activeElement?.tagName === 'TEXTAREA' ||
+          activeElement?.tagName === 'INPUT' ||
+          activeElement?.getAttribute('contenteditable') === 'true' ||
+          activeElement?.closest('.monaco-editor') ||
+          activeElement?.closest('[role="textbox"]')
+
+        if (!isInEditor) {
+          collapse.value = !collapse.value
+        }
       }
     })
 


### PR DESCRIPTION
<!--

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Sidebar 有一个快捷键可以收起或者展开，但是是全局的，加了个小判断仅限焦点不在编辑器里的状态下

### Linked Issues
None

### Additional context
None
